### PR TITLE
Se repara error al habilitar notas de venta para facturar.

### DIFF
--- a/AntBru/My Project/AssemblyInfo.vb
+++ b/AntBru/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' mediante el asterisco ('*'), como se muestra a continuación:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("3.4.4.45")>
-<Assembly: AssemblyFileVersion("3.4.4.45")>
+<Assembly: AssemblyVersion("3.4.4.46")>
+<Assembly: AssemblyFileVersion("3.4.4.46")>

--- a/AntBru/z_Menu Principal/SubMenus/Compras/Modulo_Compras.vb
+++ b/AntBru/z_Menu Principal/SubMenus/Compras/Modulo_Compras.vb
@@ -111,33 +111,33 @@ Public Class Modulo_Compras
     End Sub
 
     Private Sub Btn_OCCProveedores_Click(sender As Object, e As EventArgs) Handles Btn_OCCProveedores.Click
-        Dim Fm As New Frm_00_Asis_Compra_Menu(Modalidad)
-        Fm.Accion_Automatica = True
-        Fm.Auto_GenerarAutomaticamenteOCCProveedores = True
-        Fm.Modo_OCC = True
-        Fm.Tipo_Informe = "Asistente de compras"
-        Fm.ShowDialog(Me)
-        Fm.Dispose()
+        Dim Fm1 As New Frm_00_Asis_Compra_Menu(Modalidad)
+        Fm1.Accion_Automatica = True
+        Fm1.Auto_GenerarAutomaticamenteOCCProveedores = True
+        Fm1.Modo_OCC = True
+        Fm1.Tipo_Informe = "Asistente de compras"
+        Fm1.ShowDialog()
+        Fm1.Dispose()
     End Sub
 
     Private Sub Btn_OCCStar_Click(sender As Object, e As EventArgs) Handles Btn_OCCStar.Click
-        Dim Fm As New Frm_00_Asis_Compra_Menu(Modalidad)
-        Fm.Accion_Automatica = True
-        Fm.Auto_GenerarAutomaticamenteOCCProveedorStar = True
-        Fm.Modo_OCC = True
-        Fm.Tipo_Informe = "Asistente de compras"
-        Fm.ShowDialog(Me)
-        Fm.Dispose()
+        Dim Fm2 As New Frm_00_Asis_Compra_Menu(Modalidad)
+        Fm2.Accion_Automatica = True
+        Fm2.Auto_GenerarAutomaticamenteOCCProveedorStar = True
+        Fm2.Modo_OCC = True
+        Fm2.Tipo_Informe = "Asistente de compras"
+        Fm2.ShowDialog()
+        Fm2.Dispose()
     End Sub
 
     Private Sub Btn_NVI_Click(sender As Object, e As EventArgs) Handles Btn_NVI.Click
-        Dim Fm As New Frm_00_Asis_Compra_Menu(Modalidad)
-        Fm.Accion_Automatica = True
-        Fm.Auto_GenerarAutomaticamenteNVI = True
-        Fm.Modo_NVI = True
-        Fm.Tipo_Informe = "Asistente de compras"
-        Fm.ShowDialog(Me)
-        Fm.Dispose()
+        Dim Fm3 As New Frm_00_Asis_Compra_Menu(Modalidad)
+        Fm3.Accion_Automatica = True
+        Fm3.Auto_GenerarAutomaticamenteNVI = True
+        Fm3.Modo_NVI = True
+        Fm3.Tipo_Informe = "Asistente de compras"
+        Fm3.ShowDialog()
+        Fm3.Dispose()
     End Sub
 
     Private Sub Btn_EjecutarTodas_Click(sender As Object, e As EventArgs) Handles Btn_EjecutarTodas.Click

--- a/Librerias/BkSpecialPrograms/01 Procesos  compartidos/Documentos/01 Buscar documentos/Frm_BuscarDocumento_Mt.vb
+++ b/Librerias/BkSpecialPrograms/01 Procesos  compartidos/Documentos/01 Buscar documentos/Frm_BuscarDocumento_Mt.vb
@@ -484,12 +484,11 @@ Public Class Frm_BuscarDocumento_Mt
             Fm.Dispose()
 
             If HabilitarNVVParaFacturar Then
-                _Actualizar = _Sql.Fx_Trae_Dato(_Global_BaseBk & "Zw_Docu_Ent", "HabilitadaFac", "Idmaeedo = " & _Idmaeedo)
+                _Actualizar = _Sql.Fx_Trae_Dato(_Global_BaseBk & "Zw_Docu_Ent", "HabilitadaFac", "Idmaeedo = " & _Idmaeedo,,,, True)
+                If _Estado = "Cerrado" Then _Actualizar = True
             End If
 
-            If _Actualizar Then
-                Sb_Actualizar()
-            End If
+            If _Actualizar Then Sb_Actualizar()
 
         Catch ex As Exception
             MessageBoxEx.Show(Me, ex.Message, "Error inesperado!", MessageBoxButtons.OK, MessageBoxIcon.Stop)

--- a/Librerias/BkSpecialPrograms/01 Procesos  compartidos/Documentos/01 Buscar documentos/Frm_BusquedaDocumento_Filtro.vb
+++ b/Librerias/BkSpecialPrograms/01 Procesos  compartidos/Documentos/01 Buscar documentos/Frm_BusquedaDocumento_Filtro.vb
@@ -707,7 +707,7 @@ Buscar:
 
         If HabilitarNVVParaFacturar Then
 
-            Dim _SqlQr = "Update #Paso Set Chk = (Select HabilitadaFac From BAKAPP_PRB.dbo.Zw_Docu_Ent Z1 Where Z1.Idmaeedo = #Paso.IDMAEEDO)" & vbCrLf &
+            Dim _SqlQr = "Update #Paso Set Chk = (Select HabilitadaFac From " & _Global_BaseBk & "Zw_Docu_Ent Z1 Where Z1.Idmaeedo = #Paso.IDMAEEDO)" & vbCrLf &
                          "Delete #Paso Where Chk = 1"
 
             Consulta_sql = Replace(Consulta_sql, "--#OtrasOpciones#", _SqlQr)

--- a/Librerias/BkSpecialPrograms/03 Sistemas/Compras/Asistente de compras 2.0/Clas_Asistente_Compras.vb
+++ b/Librerias/BkSpecialPrograms/03 Sistemas/Compras/Asistente de compras 2.0/Clas_Asistente_Compras.vb
@@ -1102,12 +1102,17 @@ Public Class Clas_Asistente_Compras
                        "Update " & _Nombre_Tbl_Paso_Informe & " Set Sospecha_Baja_Rotacion = 1" & vbCrLf &
                        "Where CantSugeridaTot > 0.45" & Space(1) &
                        "And (FCV_Ult_Year+BLV_Ult_Year)-NCV_Ult_Year < 5 And Refleo = 0" &
-                       "And Fecha_Ult_Venta <= DATEADD(MONTH,-6,GETDATE())" &
+                       "--And Fecha_Ult_Venta <= DATEADD(MONTH,-3,GETDATE())" &
                        vbCrLf &
                        vbCrLf &
                        "Update " & _Nombre_Tbl_Paso_Informe & " Set Sospecha_Baja_Rotacion = 1" & vbCrLf &
                        "Where CantSugeridaTot < 0.45 And ((FCV_Ult_Year+BLV_Ult_Year)-NCV_Ult_Year between 2 And 5 OR RotMensualUd1 < 0.5)" & vbCrLf &
                        "--And Fecha_Ult_Venta <= DATEADD(MONTH,-6,GETDATE())"
+        _Sql.Ej_consulta_IDU(Consulta_sql)
+
+        'Se deja sin sospecha de baja rotación aquellos productos vendidos en los ultimos 3 meses y que tenan mas de 3 ventas con boleta
+        Consulta_sql = "Update " & _Nombre_Tbl_Paso_Informe & " Set Sospecha_Baja_Rotacion = 0" & vbCrLf &
+                       "Where (BLV_Ult_Year+FCV_Ult_Year)-NCV_Ult_Year >= 4 And Refleo = 0 And Fecha_Ult_Venta >= DATEADD(MONTH,-3,GETDATE())"
         _Sql.Ej_consulta_IDU(Consulta_sql)
 
 
@@ -1163,9 +1168,7 @@ Public Class Clas_Asistente_Compras
                "Where Sospecha_Baja_Rotacion = 0 And CantSugeridaTot > 0 And GDIodt_Ult_Year-GRIodt_Ult_Year > 5 And Comprar_Igual = 0"
             _Sql.Ej_consulta_IDU(Consulta_sql)
 
-
         End If
-
 
     End Sub
 

--- a/Librerias/BkSpecialPrograms/03 Sistemas/Compras/Asistente de compras 2.0/Formularios/Frm_01_Asis_Compra_Resultados.vb
+++ b/Librerias/BkSpecialPrograms/03 Sistemas/Compras/Asistente de compras 2.0/Formularios/Frm_01_Asis_Compra_Resultados.vb
@@ -420,7 +420,7 @@ Public Class Frm_01_Asis_Compra_Resultados
             BtnProceso_Prov_Auto_Especial.Enabled = False
         End If
 
-        Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, True, True)
+        Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, True, True) ', (Not Modo_NVI And Not Modo_OCC))
 
     End Sub
 
@@ -4207,7 +4207,7 @@ Public Class Frm_01_Asis_Compra_Resultados
         Fm.Dispose()
 
         If _Proceso_Automatico_Ejecutado Then
-            Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, False, False)
+            Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, False, False, (Not Modo_NVI And Not Modo_OCC))
             If Not String.IsNullOrEmpty(Trim(Fm_Hijo.Txt_Codigo.Text)) Then Sb_Buscar_X_Codigo()
             If Not String.IsNullOrEmpty(Trim(Fm_Hijo.Txt_Descripcion.Text)) Then Sb_Buscar_X_Descripcion()
             BtnProceso_Prov_Auto.Enabled = False
@@ -6048,6 +6048,10 @@ Public Class Frm_01_Asis_Compra_Resultados
     End Sub
 
     Sub Sb_Actualizar_Grilla_Mensual()
+
+        If _Accion_Automatica Then
+            Return
+        End If
 
         Try
 
@@ -8174,7 +8178,7 @@ Public Class Frm_01_Asis_Compra_Resultados
             Chk_Mostrar_Solo_Productos_A_Comprar.Checked = True
             Chk_Mostrar_Solo_Stock_Critico.Checked = True
 
-            Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, False, False)
+            Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, False, False, False)
 
             Consulta_sql = "Select Distinct CodProveedor As KOEN,CodSucProveedor As SUEN,
 (Select Top 1 NOKOEN From MAEEN Where KOEN = CodProveedor and SUEN = CodSucProveedor ) As RAZON,
@@ -8308,7 +8312,7 @@ Drop Table #Paso"
             Chk_Quitar_Ventas_Calzadas.Checked = True
             Chk_Quitare_Sospechosos_Stock.Checked = True
 
-            Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, False, False)
+            Sb_Refrescar_Grilla_Principal(Fm_Hijo.Grilla, False, False, False)
 
             Dim _Generar_NVI As New GeneraOccAuto.Generar_Doc_Auto
 
@@ -8819,6 +8823,10 @@ Drop Table #Paso"
 
         Dim _Bod_Solicita As String
         Dim _Tbl_Productos As DataTable
+
+        If Not CBool(_Tbl_Informe.Rows.Count) Then
+            Return
+        End If
 
         If _TblBodCompra.Rows.Count = 1 Then
 

--- a/Librerias/BkSpecialPrograms/My Project/AssemblyInfo.vb
+++ b/Librerias/BkSpecialPrograms/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' mediante el asterisco ('*'), como se muestra a continuación:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("3.5.9.62")>
-<Assembly: AssemblyFileVersion("3.5.9.62")>
+<Assembly: AssemblyVersion("3.5.9.64")>
+<Assembly: AssemblyFileVersion("3.5.9.64")>


### PR DESCRIPTION
Esto - BAKAPP_PRB.dbo.Zw_Docu_Ent
por esto - " & _Global_BaseBk & "Zw_Docu_Ent
Ahora es posible dejar en memoria los productos seleccionados para hacer pruebas en el asistente de compras.